### PR TITLE
Feature: Extended Scope Parameters

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -77,7 +77,7 @@
     "eject": "react-scripts eject",
     "format": "prettier --write --single-quote --print-width=120 --tab-width=2 'src/**/*.{ts,tsx,js,jsx}'",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "check-build": "yarn lint && yarn test",
+    "check-build": "export CI=true && export SKIP_PREFLIGHT_CHECK=true && yarn lint && yarn test",
     "clean": "rm -fr ./build",
     "deploy": "yarn clean && yarn build && touch build/.nojekyll && gh-pages -d build -t",
     "s3": "yarn clean && yarn build && aws s3 sync ./build s3://${REFEREE_BUCKET}/"

--- a/packages/client/src/components/App.test.tsx
+++ b/packages/client/src/components/App.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from '../App';
+import App from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/packages/client/src/components/canary-executor/CanaryExecutor.tsx
+++ b/packages/client/src/components/canary-executor/CanaryExecutor.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { kayentaApiService } from '../../services/';
 import { connect, ConnectedComponent } from '../connectedComponent';
 import { observer } from 'mobx-react';
-import CanaryExecutorFormView from '../canary-executor/CanaryExecutorFormView';
+import CanaryExecutorFormView from './CanaryExecutorFormView';
 import CanaryExecutorButtonSection from './CanaryExecutorButtonSection';
 import { RouterProps } from 'react-router';
 import CanaryExecutorStore from '../../stores/CanaryExecutorStore';

--- a/packages/client/src/components/canary-executor/CanaryExecutorFormView.tsx
+++ b/packages/client/src/components/canary-executor/CanaryExecutorFormView.tsx
@@ -5,10 +5,11 @@ import { boundMethod } from 'autobind-decorator';
 import * as React from 'react';
 import { Form } from 'react-bootstrap';
 import { MetadataSection } from './MetadataSection';
-import { ThresholdsSection } from '../canary-executor/ThresholdsSection';
-import TestingTypeSection from '../canary-executor/TestingTypeSection';
-import { ScopesSection } from '../canary-executor/ScopesSection';
+import { ThresholdsSection } from './ThresholdsSection';
+import TestingTypeSection from './TestingTypeSection';
+import { ScopesSection } from './ScopesSection';
 import { CanaryScope } from '../../domain/Kayenta';
+import { toJS } from 'mobx';
 
 interface Props {}
 
@@ -64,6 +65,26 @@ export default class CanaryExecutorFormView extends ConnectedComponent<Props, St
     this.stores.canaryExecutorStore.markHasTheRunButtonBeenClickedFlagAsTrue();
   }
 
+  @boundMethod
+  private handleAddNewExtendedScopeParam(type: string): void {
+    this.stores.canaryExecutorStore.addNewExtendedScopeParam(type);
+  }
+
+  @boundMethod
+  private handleExtendedScopeParamKeyChange(index: number, value: string, type: string): void {
+    this.stores.canaryExecutorStore.updateExtendedScopeParamKey(type, index, value);
+  }
+
+  @boundMethod
+  private handleExtendedScopeParamValueChange(index: number, value: string, type: string): void {
+    this.stores.canaryExecutorStore.updateExtendedScopeParamValue(type, index, value);
+  }
+
+  @boundMethod
+  private handleExtendedScopeParamDelete(index: number, type: string): void {
+    this.stores.canaryExecutorStore.deleteExtendedScopeParam(type, index);
+  }
+
   render(): React.ReactNode {
     const {
       canaryExecutionRequestObject,
@@ -71,6 +92,9 @@ export default class CanaryExecutorFormView extends ConnectedComponent<Props, St
       touched,
       hasTheRunButtonBeenClicked
     } = this.stores.canaryExecutorStore;
+
+    const controlExtendedScopes = toJS(this.stores.canaryExecutorStore.controlExtendedScopes);
+    const experimentExtendedScopes = toJS(this.stores.canaryExecutorStore.experimentExtendedScopes);
 
     return (
       <div>
@@ -113,6 +137,12 @@ export default class CanaryExecutorFormView extends ConnectedComponent<Props, St
               errors={errors}
               touched={touched}
               hasTheRunButtonBeenClicked={hasTheRunButtonBeenClicked}
+              handleAddNewExtendedScopeParam={this.handleAddNewExtendedScopeParam}
+              handleExtendedScopeParamKeyChange={this.handleExtendedScopeParamKeyChange}
+              handleExtendedScopeParamValueChange={this.handleExtendedScopeParamValueChange}
+              handleExtendedScopeParamDelete={this.handleExtendedScopeParamDelete}
+              controlExtendedScopes={controlExtendedScopes}
+              experimentExtendedScopes={experimentExtendedScopes}
             />
           </Form>
         </div>

--- a/packages/client/src/components/canary-executor/CanaryExecutorResultsRunAgainButton.tsx
+++ b/packages/client/src/components/canary-executor/CanaryExecutorResultsRunAgainButton.tsx
@@ -54,7 +54,7 @@ export default class CanaryExecutorResultsRunAgainButton extends ConnectedCompon
       this.props.history.push(
         '/dev-tools/canary-executor/results/' + this.stores.canaryExecutorStore.canaryExecutionId
       );
-      fetchCanaryResultsService.pollForCanaryExecutionComplete(this.stores.canaryExecutorStore.canaryExecutionId);
+      await fetchCanaryResultsService.pollForCanaryExecutionComplete(this.stores.canaryExecutorStore.canaryExecutionId);
     } catch (e) {
       log.error('Failed to fetch response: ', e);
       throw e;

--- a/packages/client/src/components/canary-executor/ScopeItem.scss
+++ b/packages/client/src/components/canary-executor/ScopeItem.scss
@@ -47,5 +47,9 @@
         color: #495057;
       }
     }
+
+    .esp-kv-pairs {
+      padding-bottom: 10px
+    }
   }
 }

--- a/packages/client/src/components/canary-executor/ScopesSection.tsx
+++ b/packages/client/src/components/canary-executor/ScopesSection.tsx
@@ -1,7 +1,7 @@
 import { observer } from 'mobx-react';
 import TitledSection from '../../layout/titledSection';
 import * as React from 'react';
-import ScopeItem from '../canary-executor/ScopeItem';
+import ScopeItem from './ScopeItem';
 import { CanaryScope } from '../../domain/Kayenta';
 import Row from 'react-bootstrap/Row';
 
@@ -14,7 +14,13 @@ export const ScopesSection = observer(
     touch,
     touched,
     errors,
-    hasTheRunButtonBeenClicked
+    hasTheRunButtonBeenClicked,
+    handleAddNewExtendedScopeParam,
+    handleExtendedScopeParamKeyChange,
+    handleExtendedScopeParamValueChange,
+    handleExtendedScopeParamDelete,
+    controlExtendedScopes,
+    experimentExtendedScopes
   }: {
     controlScope: CanaryScope;
     experimentScope: CanaryScope;
@@ -24,6 +30,12 @@ export const ScopesSection = observer(
     touched: KvMap<boolean>;
     errors: KvMap<string>;
     hasTheRunButtonBeenClicked: boolean;
+    handleAddNewExtendedScopeParam: (type: string) => void;
+    handleExtendedScopeParamKeyChange: (index: number, value: string, type: string) => void;
+    handleExtendedScopeParamValueChange: (index: number, value: string, type: string) => void;
+    handleExtendedScopeParamDelete: (index: number, type: string) => void;
+    controlExtendedScopes: KvPair[];
+    experimentExtendedScopes: KvPair[];
   }): JSX.Element => {
     return (
       <TitledSection title="Scopes" additionalClassname="scopes">
@@ -36,6 +48,11 @@ export const ScopesSection = observer(
             errors={errors}
             touched={touched}
             hasTheRunButtonBeenClicked={hasTheRunButtonBeenClicked}
+            handleAddNewExtendedScopeParam={handleAddNewExtendedScopeParam}
+            handleExtendedScopeParamKeyChange={handleExtendedScopeParamKeyChange}
+            handleExtendedScopeParamValueChange={handleExtendedScopeParamValueChange}
+            handleExtendedScopeParamDelete={handleExtendedScopeParamDelete}
+            extendedScopeParameters={controlExtendedScopes}
           />
           <ScopeItem
             scopeType="experiment"
@@ -46,6 +63,11 @@ export const ScopesSection = observer(
             errors={errors}
             touched={touched}
             hasTheRunButtonBeenClicked={hasTheRunButtonBeenClicked}
+            handleAddNewExtendedScopeParam={handleAddNewExtendedScopeParam}
+            handleExtendedScopeParamKeyChange={handleExtendedScopeParamKeyChange}
+            handleExtendedScopeParamValueChange={handleExtendedScopeParamValueChange}
+            handleExtendedScopeParamDelete={handleExtendedScopeParamDelete}
+            extendedScopeParameters={experimentExtendedScopes}
           />
         </Row>
       </TitledSection>

--- a/packages/client/src/components/config/MetricsSection.tsx
+++ b/packages/client/src/components/config/MetricsSection.tsx
@@ -103,7 +103,12 @@ export const MetricsSection = observer(
             </div>
           </div>
         </div>
-        {touched && errors.map(error => <Alert variant="danger">{error}</Alert>)}
+        {touched &&
+          errors.map(error => (
+            <Alert key={error} variant="danger">
+              {error}
+            </Alert>
+          ))}
       </TitledSection>
     );
   }

--- a/packages/client/src/components/docs/Docs.tsx
+++ b/packages/client/src/components/docs/Docs.tsx
@@ -73,7 +73,7 @@ export default class Docs extends ConnectedComponent<Props, Stores> {
   private handleDocumentationClick(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
     // Hijack link clicks so that we can make them go through the hash router history object thing.
     // We might be able to remove this logic when we go to the browser router.
-    OptionalUtils.safeGet(() => OptionalUtils.trimToNull((event.target as any).href).get()).ifPresent(url => {
+    OptionalUtils.safeGet(() => OptionalUtils.trimToEmpty((event.target as any).href).get()).ifPresent(url => {
       if (
         !url.startsWith(window.location.origin) ||
         OptionalUtils.safeGet(() => (event.target as any)!.target).orElse('') === '_blank' // no need to manipulate links that are opening in a new tab

--- a/packages/client/src/layout/KeyValuePair.tsx
+++ b/packages/client/src/layout/KeyValuePair.tsx
@@ -1,0 +1,44 @@
+import { Button, FormControl, InputGroup } from 'react-bootstrap';
+import * as React from 'react';
+
+export default function KeyValuePair({
+  handleDelete,
+  index,
+  onKeyChange,
+  onValueChange,
+  kvPair
+}: {
+  handleDelete: (i: number) => void;
+  index: number;
+  onKeyChange: (i: number, v: any) => void;
+  onValueChange: (i: number, v: any) => void;
+  kvPair: KvPair;
+}): JSX.Element {
+  return (
+    <InputGroup>
+      <InputGroup.Prepend>
+        <InputGroup.Text>Key: </InputGroup.Text>
+      </InputGroup.Prepend>
+      <FormControl
+        onChange={(e: any) => {
+          onKeyChange(index, e.target.value);
+        }}
+        value={kvPair.key}
+      />
+      <InputGroup.Prepend>
+        <InputGroup.Text>Value: </InputGroup.Text>
+      </InputGroup.Prepend>
+      <FormControl
+        onChange={(e: any) => {
+          onValueChange(index, e.target.value);
+        }}
+        value={kvPair.value}
+      />
+      <InputGroup.Append>
+        <Button variant="outline-danger" onMouseDown={() => handleDelete(index)}>
+          Delete
+        </Button>
+      </InputGroup.Append>
+    </InputGroup>
+  );
+}

--- a/packages/client/src/metricSources/SignalFx/SignalFxMetricModal.tsx
+++ b/packages/client/src/metricSources/SignalFx/SignalFxMetricModal.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { AbstractMetricModal } from '../../components/config/AbstractMetricModal';
 import { InlineTextGroup } from '../../layout/InlineTextGroup';
 import { FormGroup } from '../../layout/FormGroup';
-import { Button, Form, FormControl, InputGroup } from 'react-bootstrap';
+import { Button, Form } from 'react-bootstrap';
 import { boundMethod } from 'autobind-decorator';
 import SignalFxCanaryMetricSetQueryConfig from './SignalFxCanaryMetricSetQueryConfig';
 import { SIGNAL_FX_SERVICE_TYPE, SUPPORTED_AGGREGATION_METHODS } from './index';
+import KeyValuePair from '../../layout/KeyValuePair';
 
 export default class SignalFxMetricModal extends AbstractMetricModal<SignalFxCanaryMetricSetQueryConfig> {
   getQueryInitialState(): SignalFxCanaryMetricSetQueryConfig {
@@ -132,45 +133,3 @@ export default class SignalFxMetricModal extends AbstractMetricModal<SignalFxCan
     );
   }
 }
-
-const KeyValuePair = ({
-  handleDelete,
-  index,
-  onKeyChange,
-  onValueChange,
-  kvPair
-}: {
-  handleDelete: (i: number) => void;
-  index: number;
-  onKeyChange: (i: number, v: any) => void;
-  onValueChange: (i: number, v: any) => void;
-  kvPair: KvPair;
-}): JSX.Element => {
-  return (
-    <InputGroup>
-      <InputGroup.Prepend>
-        <InputGroup.Text>Key: </InputGroup.Text>
-      </InputGroup.Prepend>
-      <FormControl
-        onChange={(e: any) => {
-          onKeyChange(index, e.target.value);
-        }}
-        value={kvPair.key}
-      />
-      <InputGroup.Prepend>
-        <InputGroup.Text>Value: </InputGroup.Text>
-      </InputGroup.Prepend>
-      <FormControl
-        onChange={(e: any) => {
-          onValueChange(index, e.target.value);
-        }}
-        value={kvPair.value}
-      />
-      <InputGroup.Append>
-        <Button variant="outline-danger" onMouseDown={() => handleDelete(index)}>
-          Delete
-        </Button>
-      </InputGroup.Append>
-    </InputGroup>
-  );
-};

--- a/packages/client/src/services/DocsService.ts
+++ b/packages/client/src/services/DocsService.ts
@@ -8,7 +8,6 @@ import path from 'path-browserify';
 import Optional from 'optional-js';
 import hljs from 'highlight.js';
 import marked from 'marked';
-import { observer } from 'mobx-react';
 
 const { docsStore } = stores;
 
@@ -75,7 +74,7 @@ export default class DocsService {
   }
 
   fetchAndUpdateDocContent(path: string): void {
-    const resolvedPath = OptionalUtils.trimToNull(path).orElse(
+    const resolvedPath = OptionalUtils.trimToEmpty(path).orElse(
       OptionalUtils.safeGet(() => docsStore.tableOfContents!.home).orElse('index')
     );
 

--- a/packages/client/src/util/CanaryExecutionFactory.ts
+++ b/packages/client/src/util/CanaryExecutionFactory.ts
@@ -8,7 +8,7 @@ export default class CanaryExecutionFactory {
           controlScope: {
             scope: '',
             location: '',
-            step: 0,
+            step: 60,
             start: '',
             end: '',
             extendedScopeParams: {}
@@ -16,7 +16,7 @@ export default class CanaryExecutionFactory {
           experimentScope: {
             scope: '',
             location: '',
-            step: 0,
+            step: 60,
             start: '',
             end: '',
             extendedScopeParams: {}

--- a/packages/client/src/util/OptionalUtils.ts
+++ b/packages/client/src/util/OptionalUtils.ts
@@ -40,7 +40,7 @@ export function mapIfPresentOrElse<T>(
   }
 }
 
-export function trimToNull(value: string): Optional<string> {
+export function trimToEmpty(value: string): Optional<string> {
   const trimmed = value.trim();
   if (trimmed === '') {
     return Optional.empty();
@@ -54,5 +54,5 @@ export default {
   safeGet,
   safeGetAsync,
   mapIfPresentOrElse,
-  trimToNull
+  trimToEmpty
 };

--- a/packages/client/src/validation/executionValidators.test.ts
+++ b/packages/client/src/validation/executionValidators.test.ts
@@ -1,0 +1,79 @@
+import {
+  ALL_KVS_MUST_BE_NON_EMPTY_STRINGS,
+  DUPLICATE_SCOPE_KEYS_ERROR_MESSAGE,
+  validateExtendedScopeParams
+} from './executionValidators';
+
+test('test that validateExtendedScopeParams() returns errors as expected when there are duplicate keys', () => {
+  const expectedErrorKey = 'control-extended-scope-params';
+  const validationResults = validateExtendedScopeParams('control', [
+    { key: 'key1', value: 'foo' },
+    { key: 'key1', value: 'bar' },
+    { key: 'key2', value: 'bam' }
+  ]);
+
+  expect(validationResults.isValid).toBe(false);
+  expect(Object.keys(validationResults.errors).length).toBe(1);
+  expect(validationResults.errors).toEqual({
+    [expectedErrorKey]: DUPLICATE_SCOPE_KEYS_ERROR_MESSAGE
+  });
+});
+
+test('test that validateExtendedScopeParams() returns no errors when the data is as expected', () => {
+  const validationResults = validateExtendedScopeParams('control', [
+    { key: 'key1', value: 'foo' },
+    { key: 'key2', value: 'bam' }
+  ]);
+
+  expect(validationResults.isValid).toBe(true);
+  expect(Object.keys(validationResults.errors).length).toBe(0);
+});
+
+test('test that validateExtendedScopeParams() returns an error when a key is empty', () => {
+  const expectedErrorKey = 'control-extended-scope-params';
+  const validationResults = validateExtendedScopeParams('control', [
+    { key: ' ', value: 'foo' },
+    { key: 'key2', value: 'bam' }
+  ]);
+
+  expect(validationResults.isValid).toBe(false);
+  expect(Object.keys(validationResults.errors).length).toBe(1);
+  expect(validationResults.errors).toEqual({
+    [expectedErrorKey]: ALL_KVS_MUST_BE_NON_EMPTY_STRINGS
+  });
+});
+
+test('test that validateExtendedScopeParams() returns an error when a value is empty', () => {
+  const expectedErrorKey = 'control-extended-scope-params';
+  const validationResults = validateExtendedScopeParams('control', [
+    { key: 'key1', value: ' ' },
+    { key: 'key2', value: 'bam' }
+  ]);
+
+  expect(validationResults.isValid).toBe(false);
+  expect(Object.keys(validationResults.errors).length).toBe(1);
+  expect(validationResults.errors).toEqual({
+    [expectedErrorKey]: ALL_KVS_MUST_BE_NON_EMPTY_STRINGS
+  });
+});
+
+test('test that validateExtendedScopeParams() returns an error as expected when there are multiple errors', () => {
+  const expectedErrorKey = 'control-extended-scope-params';
+  const validationResults = validateExtendedScopeParams('control', [
+    { key: 'key1', value: ' ' },
+    { key: 'key2', value: 'bam' },
+    { key: 'key2', value: 'foo' }
+  ]);
+  expect(validationResults.isValid).toBe(false);
+  expect(Object.keys(validationResults.errors).length).toBe(1);
+  expect(validationResults.errors[expectedErrorKey]).toMatch(DUPLICATE_SCOPE_KEYS_ERROR_MESSAGE);
+  expect(validationResults.errors[expectedErrorKey]).toMatch(ALL_KVS_MUST_BE_NON_EMPTY_STRINGS);
+});
+
+test('test that validateExtendedScopeParams() returns an error with the scope type in the key', () => {
+  const keyPrefix = 'foo-bar-baz';
+  const validationResults = validateExtendedScopeParams(keyPrefix, [{ obviously: 'broken' } as any]);
+  expect(validationResults.isValid).toBe(false);
+  expect(Object.keys(validationResults.errors).length).toBe(1);
+  expect(Object.keys(validationResults.errors)[0]).toMatch(keyPrefix);
+});


### PR DESCRIPTION
Added ability to set extended scope parameters on the canary execution request in the manual canary executor.

![image](https://user-images.githubusercontent.com/711726/61315077-d9b44c80-a7b2-11e9-902a-256e79f9f5f3.png)

![image](https://user-images.githubusercontent.com/711726/61315104-e5a00e80-a7b2-11e9-93ad-f518a82b7bbe.png)

![image](https://user-images.githubusercontent.com/711726/61315169-0cf6db80-a7b3-11e9-8b3c-0071648b93db.png)
