### PR TITLE
feature: Added Error pane and store for handling errors.

### DIFF
--- a/packages/client/src/components/App.tsx
+++ b/packages/client/src/components/App.tsx
@@ -8,7 +8,7 @@ import { stores } from '../stores';
 import Header from './Header';
 import Footer from './Footer';
 import Landing from './Landing';
-import ModalViewer from './ModalViewer';
+import ModalPane from './ModalPane';
 import ConfigEditor from './config/ConfigEditor';
 import CanaryExecutor from './canary-executor/CanaryExecutor';
 import CanaryExecutorResults from './reports/canary/CanaryExecutorResults';
@@ -19,6 +19,7 @@ import 'typeface-assistant/index.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import CanaryReportViewer from './reports/canary/CanaryReportViewer';
 import ScapeReportViewer from './reports/scape/ScapeReportViewer';
+import ErrorPane from './ErrorPane';
 
 interface AppProps {}
 
@@ -28,10 +29,11 @@ export default class App extends React.Component<AppProps> {
       <BrowserRouter basename={process.env.PUBLIC_URL}>
         <Provider {...stores}>
           <div id="kayenta-config-manager">
-            <ModalViewer />
+            <ModalPane />
             <Route render={({ history }: { history: H.History }) => <Header history={history} />} />
             <div className="content-container">
               <div className="content-container-inner-wrapper">
+                <ErrorPane />
                 <Route exact={true} path="/" component={Landing} />
                 <Route path="/docs/:path(.*)" component={Docs} />
                 <Route path="/reports/canary/:executionId(.*)" component={CanaryReportViewer} />

--- a/packages/client/src/components/ErrorPane.scss
+++ b/packages/client/src/components/ErrorPane.scss
@@ -1,0 +1,5 @@
+.alert {
+  margin-bottom: 0px;
+  border-bottom: 1px solid black;
+  border-radius: 0;
+}

--- a/packages/client/src/components/ErrorPane.tsx
+++ b/packages/client/src/components/ErrorPane.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { connect, ConnectedComponent } from './connectedComponent';
+import ListStore from '../stores/ListStore';
+import { DisplayableError } from '../domain/Referee';
+import { Alert } from 'react-bootstrap';
+import { ofNullable } from '../util/OptionalUtils';
+
+import './ErrorPane.scss';
+
+interface Stores {
+  errorStore: ListStore<DisplayableError>;
+}
+
+@connect('errorStore')
+@observer
+export default class ErrorPane extends ConnectedComponent<{}, Stores> {
+  render(): React.ReactNode {
+    const { errorStore } = this.stores;
+    if (errorStore.doesHaveElements) {
+      return (
+        <div>
+          {errorStore.data.map((error, index) => (
+            <Alert
+              variant={ofNullable(error.variant).orElse('danger')}
+              onClose={() => errorStore.removeIndex(index)}
+              dismissible
+            >
+              <Alert.Heading>{error.heading}</Alert.Heading>
+              {error.content}
+            </Alert>
+          ))}
+        </div>
+      );
+    } else {
+      return <div />;
+    }
+  }
+}

--- a/packages/client/src/components/ModalPane.tsx
+++ b/packages/client/src/components/ModalPane.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import { connect, ConnectedComponent } from './connectedComponent';
-import StackStore from '../stores/StackStore';
+import ListStore from '../stores/ListStore';
 
 interface Stores {
-  modalStore: StackStore<JSX.Element>;
+  modalStore: ListStore<JSX.Element>;
 }
 
 @connect('modalStore')
 @observer
-export default class ModalViewer extends ConnectedComponent<{}, Stores> {
+export default class ModalPane extends ConnectedComponent<{}, Stores> {
   render(): React.ReactNode {
     if (this.stores.modalStore.doesHaveElements) {
       return <div>{this.stores.modalStore.peek}</div>;

--- a/packages/client/src/components/config/ConfigFormView.tsx
+++ b/packages/client/src/components/config/ConfigFormView.tsx
@@ -5,7 +5,7 @@ import { CanaryMetricConfig, CanaryMetricSetQueryConfig } from '../../domain/Kay
 import { connect, ConnectedComponent } from '../connectedComponent';
 import ConfigEditorStore from '../../stores/ConfigEditorStore';
 import { observer } from 'mobx-react';
-import StackStore from '../../stores/StackStore';
+import ListStore from '../../stores/ListStore';
 import { boundMethod } from 'autobind-decorator';
 import { ScoringSection } from './ScoringSection';
 import { NameAndDescriptionSection } from './NameAndDescriptionSection';
@@ -17,7 +17,7 @@ import { MetricModalProps } from './AbstractMetricModal';
 interface Props extends RouterProps {}
 interface Stores {
   configEditorStore: ConfigEditorStore;
-  modalStore: StackStore<JSX.Element>;
+  modalStore: ListStore<JSX.Element>;
 }
 
 @connect(

--- a/packages/client/src/domain/Referee.ts
+++ b/packages/client/src/domain/Referee.ts
@@ -17,3 +17,9 @@ export interface ValidationResultsWrapper {
   errors: KvMap<string>;
   isValid: boolean;
 }
+
+export interface DisplayableError {
+  variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'dark' | 'light';
+  heading: string;
+  content: JSX.Element;
+}

--- a/packages/client/src/stores/ListStore.ts
+++ b/packages/client/src/stores/ListStore.ts
@@ -5,7 +5,7 @@ export class EmptyStackError extends Error {}
 /**
  * Array backed generic stack store
  */
-export default class StackStore<T> {
+export default class ListStore<T> {
   @observable
   data: T[] = [];
 
@@ -24,6 +24,11 @@ export default class StackStore<T> {
   pop(): T {
     this.assertDataHasElements();
     return this.data.pop()!;
+  }
+
+  @action.bound
+  removeIndex(index: number): void {
+    this.data = observable.array([...this.data.slice(0, index), ...this.data.slice(index + 1)]);
   }
 
   @computed

--- a/packages/client/src/stores/index.ts
+++ b/packages/client/src/stores/index.ts
@@ -1,13 +1,14 @@
 import ConfigEditorStore from './ConfigEditorStore';
 import DocsStore from './DocsStore';
-import StackStore from './StackStore';
+import ListStore from './ListStore';
 import CanaryExecutorStore from './CanaryExecutorStore';
 import ReportStore from './ReportStore';
 
 export const stores = {
   configEditorStore: new ConfigEditorStore(),
   docsStore: new DocsStore(),
-  modalStore: new StackStore(),
+  modalStore: new ListStore(),
+  errorStore: new ListStore(),
   canaryExecutorStore: new CanaryExecutorStore(),
   reportStore: new ReportStore()
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/711726/66155443-7b8a4f00-e5d4-11e9-9663-be96e776f7fd.png)


```typescript
  errorStore.push({
    heading: 'I am an error',
    content: <div>I am some sub content</div>
  });

  errorStore.push({
    variant: 'warning',
    heading: 'Warning',
    content: <div>Something happened, but its not the end of the world</div>
  });

  errorStore.push({
    heading: 'I am another error',
    content: <div>I am some sub content</div>
  });
```