### PR TITLE
fix: add card to the Report Viewer when there's less than 50 data points

### DIFF
--- a/packages/client/src/components/reports/canary/CanaryRunResult.tsx
+++ b/packages/client/src/components/reports/canary/CanaryRunResult.tsx
@@ -98,6 +98,7 @@ export const CanaryRunResult = observer(
               />
             ) : (
               <IndividualMetricView
+                config={canaryConfig}
                 selectedMetric={selectedMetric}
                 metricSourceType={metricSourceType}
                 lifetime={lifetime}

--- a/packages/client/src/components/reports/scape/ScapeRunResult.tsx
+++ b/packages/client/src/components/reports/scape/ScapeRunResult.tsx
@@ -90,6 +90,7 @@ export const ScapeRunResult = observer(
             />
           ) : (
             <IndividualMetricView
+              config={canaryConfig}
               selectedMetric={selectedMetric}
               metricSourceType={metricSourceType}
               lifetime={lifetime}

--- a/packages/client/src/components/shared/IndividualMetricView.scss
+++ b/packages/client/src/components/shared/IndividualMetricView.scss
@@ -7,6 +7,19 @@
   overflow: auto;
   width: 100%;
 
+  .info-card {
+    margin: 10px;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+
+    .info-content{
+      padding: 0px 20px 0px 20px;
+      display: flex;
+    }
+  }
+
   .graph-card {
     margin: 10px;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);

--- a/packages/client/src/components/shared/IndividualMetricView.scss
+++ b/packages/client/src/components/shared/IndividualMetricView.scss
@@ -15,7 +15,7 @@
     flex-direction: column;
 
     .info-content{
-      padding: 0px 20px 0px 20px;
+      padding: 10px 20px 10px 20px;
       display: flex;
     }
   }

--- a/packages/client/src/components/shared/IndividualMetricView.tsx
+++ b/packages/client/src/components/shared/IndividualMetricView.tsx
@@ -122,7 +122,7 @@ export default class IndividualMetricView extends React.Component<IndividualMetr
 
     return (
       <div className="individual-metric-view">
-        {filteredControlDataPointsLength < 16 && (
+        {filteredControlDataPointsLength < 50 && (
           <div className="info-card warning-border">
             <div className="info-content">
               This metric has fewer than 50 data points

--- a/packages/client/src/styles/shared.scss
+++ b/packages/client/src/styles/shared.scss
@@ -107,6 +107,10 @@ $fail-color: $error;
   border-left: 5px solid $pass-color;
 }
 
+.warning-border {
+  border-left: 5px solid $marginal-color;
+}
+
 .nodata {
   background: $nodata;
 }


### PR DESCRIPTION
* Add a card above the graph to make it clear whether the metric failed or not
* Add a notation that the individual metric is critical