### PR TITLE
fix: truncate the tool tip value to be shorter than 4 decimal places.

### DIFF
--- a/packages/client/src/components/shared/IndividualMetricView.tsx
+++ b/packages/client/src/components/shared/IndividualMetricView.tsx
@@ -22,6 +22,8 @@ interface IndividualMetricViewProps {
   metricSetPairsByIdMap: KvMap<MetricSetPair>;
 }
 
+const roundToFourDecimalPlaces = (num: number) => Math.round(num * 10000) / 10000;
+
 const ROUNDING_POSITION: number = 4;
 
 export const filterNansFromData = (data: number[]): number[] => {
@@ -102,7 +104,7 @@ export default class IndividualMetricView extends React.Component<IndividualMetr
           borderColor: 'rgb(6, 89, 137)',
           borderWidth: 2,
           fill: false,
-          data: controlData.slice()
+          data: controlData.slice().map(n => roundToFourDecimalPlaces(n))
         },
         {
           label: 'Canary',
@@ -110,7 +112,7 @@ export default class IndividualMetricView extends React.Component<IndividualMetr
           borderColor: 'rgb(240, 111, 31)',
           borderWidth: 2,
           fill: false,
-          data: experimentData.slice()
+          data: experimentData.slice().map(n => roundToFourDecimalPlaces(n))
         }
       ]
     };


### PR DESCRIPTION
In the report viewer, when the user hovers over the graph, the tool tip value that displays the data should be truncated. As an example, the current values are showing as 230490223.2309420432, which makes it hard to read.
Before:
<img width="831" alt="Screen Shot 2019-12-13 at 12 20 18 AM" src="https://user-images.githubusercontent.com/6239450/70784418-75d08880-1d3e-11ea-867c-dcae800b9d94.png">
After:
<img width="837" alt="Screen Shot 2019-12-13 at 12 10 49 AM" src="https://user-images.githubusercontent.com/6239450/70784415-7537f200-1d3e-11ea-9f28-3dc3bd95fb82.png">
