### PR TITLE
fix: add error message when group weights are misconfigured

### DIFF
--- a/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
+++ b/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
@@ -26,6 +26,7 @@ import ListStore from '../../../stores/ListStore';
 import { DisplayableError } from '../../../domain/Referee';
 import './ScapeReportViewer.scss';
 import Optional from 'optional-js';
+import { add } from '../../../validation/configValidators';
 
 interface PathParams {
   executionId: string;
@@ -83,6 +84,22 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
           )
         );
         this.stores.configEditorStore.setCanaryConfigObject(canaryConfig);
+      }
+
+      const totalGroupWeights: number = Object.values(this.stores.configEditorStore.computedGroupWeights).reduce(
+        add,
+        0
+      );
+      if (totalGroupWeights !== 100) {
+        log.error(`Configuration Error: Group weights need to equal 100.`);
+        this.stores.errorStore.push({
+          heading: `Configuration Error: Group weights need to equal 100.`,
+          content: (
+            <div>
+              Your group weights equal {totalGroupWeights}. This might affect your canary results. Please click "Go To Config" to set group weights to 100.
+            </div>
+          )
+        });
       }
 
       // TODO confirm if this is the best way to check if map exists before calling the API

--- a/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
+++ b/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
@@ -91,9 +91,9 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
         0
       );
       if (totalGroupWeights !== 100) {
-        log.error(`Configuration Error: Group weights need to equal 100.`);
+        log.error(`Configuration Error: Group weights need to add up to 100.`);
         this.stores.errorStore.push({
-          heading: `Configuration Error: Group weights need to equal 100.`,
+          heading: `Configuration Error: Group weights need to add up to 100.`,
           content: (
             <div>
               Your group weights equal {totalGroupWeights}. This might affect your canary results. Please click "Go To Config" to set group weights to 100.


### PR DESCRIPTION
We had a use case where a customer manually changed their canary config and ended up with group weights that did not equal 100. This ended up failing their canary even though all the metrics passed which was confusing for them to debug. 

This change adds an error message if the group weights are misconfigured:

![image](https://user-images.githubusercontent.com/42477256/76470990-bd52c900-63ae-11ea-96b4-4dc2c1d3d85e.png)
