### PR TITLE
feat: enable in progress reports

### DIFF
--- a/packages/client/src/components/reports/scape/ScapeExecutionsInProgressResult.scss
+++ b/packages/client/src/components/reports/scape/ScapeExecutionsInProgressResult.scss
@@ -1,0 +1,112 @@
+@import '../../../styles/shared.scss';
+
+$selected-size: 100px;
+$un-selected-size: 85px;
+
+.scape-in-progress-report-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  .scape-metadata-container {
+    padding-top: 2px;
+  }
+
+  .scape-executions {
+    padding-top: 50px;
+    display: flex;
+    flex-flow: column;
+    height: 100%;
+
+    .scape-executions-tabs {
+      padding-left: 50px;
+      padding-right: 50px;
+      display: flex;
+
+      .scape-tab-wrapper {
+        display: flex;
+        flex-flow: column;
+
+        .scape-tab {
+          display: flex;
+          margin-top: 2px;
+          margin-left: 15px;
+          justify-content: center;
+          border: 2px solid $black;
+          border-radius: 8px;
+          height: 50px;
+          width: $un-selected-size;
+
+          .score-wrapper {
+            display: flex;
+            flex-flow: column;
+            justify-content: center;
+            justify-self: center;
+            text-align: center;
+
+            .score {
+              margin-bottom: -5px;
+              font-weight: bold;
+              font-size: 25px;
+              @extend .content-font;
+            }
+
+            .label {
+              margin-top: -4px;
+              margin-bottom: 1px;
+              font-weight: bold;
+              font-size: 15px;
+            }
+          }
+        }
+
+        .selected {
+          z-index: 1000;
+          height: 60px;
+          width: $selected-size;
+          margin-top: -1px;
+          border-radius: 10px 10px 0 0;
+        }
+      }
+    }
+    @media screen and (max-width: 700px) {
+      .scape-executions-tabs {
+        flex-direction: column;
+        align-content: center;
+        padding: 0;
+      }
+    }
+
+    .scape-executions-result-wrapper {
+      border-top-left-radius: 20px;
+      border-top-right-radius: 20px;
+      border-top: 3px solid $black;
+      border-right: 3px solid $black;
+      border-left: 3px solid $black;
+      margin-top: -3px;
+      z-index: 1;
+      height: 100%;
+
+      .img-container {
+        margin: 150px;
+        height: 100%;
+
+        #logo {
+          display: block;
+          margin: 0 auto;
+          width: 40%;
+          height: 40%;
+        }
+      }
+    }
+  }
+
+  .message-bar {
+    margin-top: 30px;
+    padding: 5px 0 5px 0;
+    text-align: center;
+    background-color: $light-gray;
+    font-size: 20px;
+    @extend .heading-font;
+  }
+}

--- a/packages/client/src/components/reports/scape/ScapeExecutionsInProgressResult.tsx
+++ b/packages/client/src/components/reports/scape/ScapeExecutionsInProgressResult.tsx
@@ -60,7 +60,6 @@ interface Props {
 
 interface State {
   selectedCAEIndex: number;
-  isSelectedRunComplete: boolean;
 }
 
 class RefereeStageMetadata {
@@ -84,13 +83,12 @@ export default class ScapeExecutionsInProgressResult extends React.Component<Pro
     super(props);
 
     this.state = {
-      selectedCAEIndex: safeGet(() => this.props.results.canaryExecutionResults.length - 1).orElse(0),
-      isSelectedRunComplete: safeGet(() => this.props.results.canaryExecutionResults.length > 0).orElse(false)
+      selectedCAEIndex: safeGet(() => this.props.results.canaryExecutionResults.length - 1).orElse(0)
     };
   }
 
   onCAETabClick(index: number, status: string) {
-    this.setState({ selectedCAEIndex: index, isSelectedRunComplete: status !== stageStatus.IN_PROGRESS });
+    this.setState({ selectedCAEIndex: index });
   }
 
   render(): React.ReactNode {
@@ -206,7 +204,7 @@ export default class ScapeExecutionsInProgressResult extends React.Component<Pro
             })}
           </div>
           <div className="scape-executions-result-wrapper">
-            {this.state.isSelectedRunComplete ? (
+            {safeGet(() => this.props.results.canaryExecutionResults.length > 0).orElse(false) ? (
               isTerminalFailure(selectedCanaryExecutionResult) ? (
                 <div className="terminal-canary-wrapper">
                   <TerminalResult exception={selectedCanaryExecutionResult.exception} />

--- a/packages/client/src/components/reports/scape/ScapeExecutionsInProgressResult.tsx
+++ b/packages/client/src/components/reports/scape/ScapeExecutionsInProgressResult.tsx
@@ -1,0 +1,233 @@
+import * as React from 'react';
+import {
+  CanaryAnalysisExecutionRequest,
+  CanaryAnalysisExecutionRequestScope,
+  CanaryAnalysisExecutionResult,
+  CanaryAnalysisResult,
+  CanaryClassifierThresholdsConfig,
+  CanaryConfig,
+  CanaryExecutionResult,
+  CanaryJudgeGroupScore,
+  CanaryResult,
+  MetricSetPair,
+  StageMetadata
+} from '../../../domain/Kayenta';
+import ScapeMetadataSection from './ScapeMetadataSection';
+import { safeGet } from '../../../util/OptionalUtils';
+import { ScapeRunResult } from './ScapeRunResult';
+import './ScapeExecutionsInProgressResult.scss';
+import ScoreClassUtils from '../../../util/ScoreClassUtils';
+import TerminalResult from '../../shared/TerminalResult';
+import TitledSection from '../../../layout/titledSection';
+import { observer } from 'mobx-react';
+import logo from '../../../assets/logo.svg';
+
+enum stageStatus {
+  SUCCEEDED = 'SUCCEEDED',
+  TERMINAL = 'TERMINAL',
+  IN_PROGRESS = 'in-progress'
+}
+
+interface Props {
+  stageStatusList: StageMetadata[];
+  application: string;
+  user: string;
+  metricSourceType: string;
+  applicationMetadata: KvMap<string>;
+  metricsAccountName: string;
+  storageAccountName: string;
+  startTime: string;
+  endTime: string;
+  lifetime: number;
+  thresholds: CanaryClassifierThresholdsConfig;
+  results: CanaryAnalysisExecutionResult;
+  selectedCanaryExecutionResult: CanaryExecutionResult;
+  result: CanaryResult;
+  selectedMetric: string;
+  request: CanaryAnalysisExecutionRequest;
+  canaryConfig: CanaryConfig;
+  canaryAnalysisResultByIdMap: KvMap<CanaryAnalysisResult>;
+  idListByMetricGroupNameMap: KvMap<string[]>;
+  groupScoreByMetricGroupNameMap: KvMap<CanaryJudgeGroupScore>;
+  metricSetPairsByIdMap: KvMap<MetricSetPair>;
+  classificationCountMap: Map<string, number>;
+  metricGroupNamesDescByWeight: string[];
+  displayMetricOverview: boolean;
+  handleOverviewSelection: () => void;
+  handleCanaryRunSelection: (canaryExecutionResult: CanaryExecutionResult) => void;
+  handleMetricSelection: (id: string) => void;
+  handleGoToConfigButtonClick: (config: CanaryConfig) => void;
+}
+
+interface State {
+  selectedCAEIndex: number;
+  isSelectedRunComplete: boolean;
+}
+
+const isTerminalFailure = (selectedCanaryExecutionResult: CanaryExecutionResult) =>
+  selectedCanaryExecutionResult.executionStatus === stageStatus.TERMINAL && selectedCanaryExecutionResult.exception;
+
+@observer
+export default class ScapeExecutionsInProgressResult extends React.Component<Props, State> {
+  constructor(props: Readonly<Props>) {
+    super(props);
+
+    this.state = {
+      selectedCAEIndex: safeGet(() => this.props.results.canaryExecutionResults.length - 1).orElse(0),
+      isSelectedRunComplete: safeGet(() => this.props.results.canaryExecutionResults.length > 0).orElse(false)
+    };
+  }
+
+  onCAETabClick(index: number, status: string) {
+    this.setState({ selectedCAEIndex: index, isSelectedRunComplete: status !== stageStatus.IN_PROGRESS });
+  }
+
+  render(): React.ReactNode {
+    const {
+      stageStatusList,
+      application,
+      user,
+      metricSourceType,
+      applicationMetadata,
+      metricsAccountName,
+      storageAccountName,
+      startTime,
+      endTime,
+      lifetime,
+      thresholds,
+      results,
+      selectedCanaryExecutionResult,
+      result,
+      selectedMetric,
+      request,
+      canaryConfig,
+      canaryAnalysisResultByIdMap,
+      idListByMetricGroupNameMap,
+      groupScoreByMetricGroupNameMap,
+      metricSetPairsByIdMap,
+      classificationCountMap,
+      metricGroupNamesDescByWeight,
+      displayMetricOverview,
+      handleOverviewSelection,
+      handleCanaryRunSelection,
+      handleMetricSelection,
+      handleGoToConfigButtonClick
+    } = this.props;
+
+    const selectedRunNumber = this.state.selectedCAEIndex + 1;
+    const runCanaryStages = stageStatusList.filter(stageMetadata => stageMetadata.type === 'runCanary');
+
+    return (
+      <div className="scape-in-progress-report-container">
+        <div className="scape-metadata-container">
+          <TitledSection title="Canary Report" />
+          <ScapeMetadataSection
+            application={application as string}
+            user={user as string}
+            applicationMetadata={applicationMetadata as KvMap<string>}
+            metricsAccountName={metricsAccountName as string}
+            storageAccountName={storageAccountName as string}
+            startTime={startTime as string}
+            endTime={endTime as string}
+            lifetime={lifetime as number}
+            request={request as CanaryAnalysisExecutionRequest}
+            scope={safeGet(() => request.scopes[0]).get() as CanaryAnalysisExecutionRequestScope}
+            canaryConfig={canaryConfig as CanaryConfig}
+            handleGoToConfigButtonClick={handleGoToConfigButtonClick}
+          />
+        </div>
+        <div className="message-bar">Canary Analysis In Progress</div>
+        <div className="scape-executions">
+          <div className="scape-executions-tabs">
+            {runCanaryStages.map((stageMetadata, index) => {
+              // TODO clean up this code
+              let score: string = '...';
+              let status: string;
+              let availableResult: CanaryExecutionResult | undefined = undefined;
+
+              if (stageMetadata.status === stageStatus.TERMINAL) {
+                score = '0';
+                status = 'fail';
+              } else if (stageMetadata.status === stageStatus.SUCCEEDED) {
+                availableResult = results.canaryExecutionResults.find(
+                  result => result.executionId === stageMetadata.executionId
+                );
+                if (availableResult)
+                  score = safeGet(() => availableResult)
+                    .get()
+                    .result.judgeResult!.score.score.toFixed(0)
+                    .toString();
+                status = ScoreClassUtils.getClassFromScore(parseInt(score), results.canaryScores, thresholds, index);
+              } else {
+                status = 'in-progress';
+              }
+
+              return (
+                <div className="scape-tab-wrapper" key={stageMetadata.name}>
+                  <div
+                    key={`execution-${index}`}
+                    className={[
+                      'btn',
+                      'scape-tab',
+                      status,
+                      index === this.state.selectedCAEIndex ? 'selected' : 'not-selected'
+                    ].join(' ')}
+                    onClick={() => {
+                      this.onCAETabClick(index, status);
+                      if (availableResult) {
+                        handleCanaryRunSelection(availableResult);
+                      }
+                    }}
+                  >
+                    <div className="score-wrapper headline-md-marketing">
+                      <div className="score">{score}</div>
+                      <div className="label uppercase">{status === stageStatus.IN_PROGRESS ? '' : status}</div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div className="scape-executions-result-wrapper">
+            {this.state.isSelectedRunComplete ? (
+              isTerminalFailure(selectedCanaryExecutionResult) ? (
+                <div className="terminal-canary-wrapper">
+                  <TerminalResult exception={selectedCanaryExecutionResult.exception} />
+                </div>
+              ) : (
+                <ScapeRunResult
+                  application={application as string}
+                  user={user as string}
+                  metricSourceType={metricSourceType as string}
+                  metricsAccountName={metricsAccountName as string}
+                  storageAccountName={storageAccountName as string}
+                  thresholds={thresholds as CanaryClassifierThresholdsConfig}
+                  lifetime={lifetime as number}
+                  selectedCanaryExecutionResult={selectedCanaryExecutionResult as CanaryExecutionResult}
+                  result={result as CanaryResult}
+                  totalRuns={runCanaryStages.length as number}
+                  selectedRunNumber={selectedRunNumber as number}
+                  selectedMetric={selectedMetric as string}
+                  canaryConfig={canaryConfig as CanaryConfig}
+                  canaryAnalysisResultByIdMap={canaryAnalysisResultByIdMap as KvMap<CanaryAnalysisResult>}
+                  idListByMetricGroupNameMap={idListByMetricGroupNameMap as KvMap<string[]>}
+                  groupScoreByMetricGroupNameMap={groupScoreByMetricGroupNameMap as KvMap<CanaryJudgeGroupScore>}
+                  metricSetPairsByIdMap={metricSetPairsByIdMap as KvMap<MetricSetPair>}
+                  classificationCountMap={classificationCountMap as Map<string, number>}
+                  metricGroupNamesDescByWeight={metricGroupNamesDescByWeight as string[]}
+                  displayMetricOverview={displayMetricOverview as boolean}
+                  handleOverviewSelection={handleOverviewSelection}
+                  handleMetricSelection={handleMetricSelection}
+                />
+              )
+            ) : (
+              <div className="img-container">
+                <img id="logo" src={logo} alt="" />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/client/src/components/reports/scape/ScapeExecutionsInProgressResult.tsx
+++ b/packages/client/src/components/reports/scape/ScapeExecutionsInProgressResult.tsx
@@ -140,26 +140,27 @@ export default class ScapeExecutionsInProgressResult extends React.Component<Pro
         <div className="scape-executions">
           <div className="scape-executions-tabs">
             {runCanaryStages.map((stageMetadata, index) => {
-              // TODO clean up this code
+              // TODO turn this conditional logic into a function
               let score: string = '...';
-              let status: string;
+              let status: string = 'in-progress';
               let availableResult: CanaryExecutionResult | undefined = undefined;
 
               if (stageMetadata.status === stageStatus.TERMINAL) {
                 score = '0';
                 status = 'fail';
               } else if (stageMetadata.status === stageStatus.SUCCEEDED) {
-                availableResult = results.canaryExecutionResults.find(
-                  result => result.executionId === stageMetadata.executionId
+                // TODO error can show up here when canaryExecutionResults is undefined
+                safeGet(() => results.canaryExecutionResults).ifPresent(
+                  (results: CanaryExecutionResult[]) =>
+                    (availableResult = results.find(result => result.executionId === stageMetadata.executionId))
                 );
-                if (availableResult)
+                if (availableResult) {
                   score = safeGet(() => availableResult)
                     .get()
                     .result.judgeResult!.score.score.toFixed(0)
                     .toString();
-                status = ScoreClassUtils.getClassFromScore(parseInt(score), results.canaryScores, thresholds, index);
-              } else {
-                status = 'in-progress';
+                  status = ScoreClassUtils.getClassFromScore(parseInt(score), results.canaryScores, thresholds, index);
+                }
               }
 
               return (

--- a/packages/client/src/components/reports/scape/ScapeMetadataSection.scss
+++ b/packages/client/src/components/reports/scape/ScapeMetadataSection.scss
@@ -22,7 +22,7 @@
       .scape-metadata-properties-column {
         display: flex;
         flex-direction: column;
-        max-width: 140px;
+        max-width: 160px;
 
         .kv-wrapper {
           display: flex;

--- a/packages/client/src/components/reports/scape/ScapeMetadataSection.tsx
+++ b/packages/client/src/components/reports/scape/ScapeMetadataSection.tsx
@@ -25,6 +25,10 @@ interface Props {
   handleGoToConfigButtonClick: (config: CanaryConfig) => void;
 }
 
+enum time {
+  IN_PROGRESS = 'in-progress'
+}
+
 export default class ScapeMetadataSection extends React.Component<Props> {
   render(): React.ReactNode {
     const {
@@ -121,7 +125,11 @@ export default class ScapeMetadataSection extends React.Component<Props> {
                 </div>
                 <div className="scope-item-wrapper timestamp-min-width">
                   <FontAwesomeIcon className="img hourglass" size="lg" color="black" icon={faHourglassEnd} />
-                  <ToggleableTimeStamp timeStamp={scope.endTimeIso ? scope.endTimeIso : endTime} />
+                  {endTime === time.IN_PROGRESS ? (
+                    'In Progress'
+                  ) : (
+                    <ToggleableTimeStamp timeStamp={scope.endTimeIso ? scope.endTimeIso : endTime} />
+                  )}
                 </div>
               </div>
             </div>

--- a/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
+++ b/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
@@ -60,9 +60,7 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
     const executionId = Optional.ofNullable(this.props.match.params.executionId).orElse('');
 
     try {
-      scapeExecutionStatusResponse = await kayentaApiService.fetchCanaryAnalysisExecutionStatusResponseFromNikeKayenta(
-        executionId
-      );
+      scapeExecutionStatusResponse = await kayentaApiService.fetchCanaryAnalysisExecutionStatusResponse(executionId);
       this.stores.reportStore.updateFromScapeResponse(scapeExecutionStatusResponse);
     } catch (e) {
       log.error(`Failed to fetch the canaryExecutionStatusResponse for id: ${executionId}`);
@@ -187,7 +185,6 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
                 storageAccountName={scapeExecutionStatusResponse.storageAccountName as string}
                 applicationMetadata={reportStore.applicationMetadata as KvMap<string>}
                 startTime={reportStore.startTime as string}
-                endTime={reportStore.endTime as string}
                 lifetime={reportStore.lifetime as number}
                 thresholds={reportStore.thresholds as CanaryClassifierThresholdsConfig}
                 results={reportStore.scapeResults as CanaryAnalysisExecutionResult}

--- a/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
+++ b/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
@@ -60,7 +60,9 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
     const executionId = Optional.ofNullable(this.props.match.params.executionId).orElse('');
 
     try {
-      scapeExecutionStatusResponse = await kayentaApiService.fetchCanaryAnalysisExecutionStatusResponse(executionId);
+      scapeExecutionStatusResponse = await kayentaApiService.fetchCanaryAnalysisExecutionStatusResponseFromNikeKayenta(
+        executionId
+      );
       this.stores.reportStore.updateFromScapeResponse(scapeExecutionStatusResponse);
     } catch (e) {
       log.error(`Failed to fetch the canaryExecutionStatusResponse for id: ${executionId}`);

--- a/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
+++ b/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
@@ -78,8 +78,6 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
         this.stores.configEditorStore.setCanaryConfigObject(response.canaryConfig);
       }
       if (!this.stores.configEditorStore.canaryConfigObject) {
-        console.log('fetching canary config object');
-
         canaryConfig = await kayentaApiService.fetchCanaryConfig(
           ofNullable(response.canaryConfigId).orElseThrow(
             () => new Error('Expected either a canary config id or canary config object to be present')

--- a/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
+++ b/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
@@ -99,7 +99,8 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
           heading: `Configuration Error: Group weights need to add up to 100.`,
           content: (
             <div>
-              Your group weights equal {totalGroupWeights}. This might affect your canary results. Please click "Go To Config" to set group weights to 100.
+              Your group weights equal {totalGroupWeights}. This might affect your canary results. Please click "Go To
+              Config" to set group weights to 100.
             </div>
           )
         });

--- a/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
+++ b/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
@@ -83,10 +83,11 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
 
     this.fetchScapeResponse(executionId);
     const intervalId = setInterval(function() {
-      self.fetchScapeResponse(executionId);
       const scapeExecutionStatusResponseValue = safeGet(() => self.state.scapeExecutionStatusResponse);
       if (scapeExecutionStatusResponseValue.isPresent() ? scapeExecutionStatusResponseValue.get().complete : false) {
         clearInterval(intervalId);
+      } else {
+        self.fetchScapeResponse(executionId);
       }
     }, REPORT_UPDATE_WAIT_IN_MS);
 

--- a/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
+++ b/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
@@ -26,6 +26,7 @@ import ListStore from '../../../stores/ListStore';
 import { DisplayableError } from '../../../domain/Referee';
 import './ScapeReportViewer.scss';
 import Optional from 'optional-js';
+import ScapeExecutionsInProgressResult from './ScapeExecutionsInProgressResult';
 import { add } from '../../../validation/configValidators';
 
 interface PathParams {
@@ -170,6 +171,43 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
               handleMetricSelection={reportStore.handleMetricSelection}
               handleGoToConfigButtonClick={this.handleGoToConfigButtonClick}
             />
+          );
+        } else if (!scapeExecutionStatusResponse.complete && reportStore.scapeExecutionRequest) {
+          return (
+            <div>
+              <ScapeExecutionsInProgressResult
+                stageStatusList={ofNullable(scapeExecutionStatusResponse.stageStatus).orElse([])}
+                application={ofNullable(scapeExecutionStatusResponse.application).orElse('ad-hoc') as string}
+                user={ofNullable(scapeExecutionStatusResponse.user).orElse('anonymous') as string}
+                metricSourceType={configEditorStore.metricSourceType as string}
+                metricsAccountName={scapeExecutionStatusResponse.metricsAccountName as string}
+                storageAccountName={scapeExecutionStatusResponse.storageAccountName as string}
+                applicationMetadata={reportStore.applicationMetadata as KvMap<string>}
+                startTime={reportStore.startTime as string}
+                endTime={reportStore.endTime as string}
+                lifetime={reportStore.lifetime as number}
+                thresholds={reportStore.thresholds as CanaryClassifierThresholdsConfig}
+                results={reportStore.scapeResults as CanaryAnalysisExecutionResult}
+                selectedCanaryExecutionResult={reportStore.selectedCanaryExecutionResult as CanaryExecutionResult}
+                result={reportStore.canaryResult as CanaryResult}
+                selectedMetric={reportStore.selectedMetric as string}
+                request={reportStore.scapeExecutionRequest as CanaryAnalysisExecutionRequest}
+                canaryConfig={configEditorStore.canaryConfigObject as CanaryConfig}
+                canaryAnalysisResultByIdMap={reportStore.canaryAnalysisResultByIdMap as KvMap<CanaryAnalysisResult>}
+                idListByMetricGroupNameMap={reportStore.idListByMetricGroupNameMap as KvMap<string[]>}
+                groupScoreByMetricGroupNameMap={
+                  reportStore.groupScoreByMetricGroupNameMap as KvMap<CanaryJudgeGroupScore>
+                }
+                metricSetPairsByIdMap={reportStore.metricSetPairsByIdMap as KvMap<MetricSetPair>}
+                classificationCountMap={reportStore.classificationCountMap as Map<string, number>}
+                metricGroupNamesDescByWeight={configEditorStore.metricGroupNamesDescByWeight as string[]}
+                displayMetricOverview={reportStore.displayMetricOverview as boolean}
+                handleOverviewSelection={reportStore.handleOverviewSelection}
+                handleCanaryRunSelection={this.handleCanaryRunSelection}
+                handleMetricSelection={reportStore.handleMetricSelection}
+                handleGoToConfigButtonClick={this.handleGoToConfigButtonClick}
+              />
+            </div>
           );
         } else {
           log.error(`Failed to fetch the canaryExecutionStatusResponse for id: ${this.state.executionId}`);

--- a/packages/client/src/domain/Kayenta.ts
+++ b/packages/client/src/domain/Kayenta.ts
@@ -243,7 +243,7 @@ export interface StageMetadata {
   type: string;
   name: string;
   status: string;
-  executionId: string;
+  executionId?: string;
 }
 
 export interface CanaryAnalysisExecutionResult {

--- a/packages/client/src/domain/Kayenta.ts
+++ b/packages/client/src/domain/Kayenta.ts
@@ -243,6 +243,7 @@ export interface StageMetadata {
   type: string;
   name: string;
   status: string;
+  executionId: string;
 }
 
 export interface CanaryAnalysisExecutionResult {

--- a/packages/client/src/metricSources/Prometheus/PrometheusCanaryMetricSetQueryConfig.ts
+++ b/packages/client/src/metricSources/Prometheus/PrometheusCanaryMetricSetQueryConfig.ts
@@ -4,5 +4,5 @@ import { CanaryMetricSetQueryConfig } from '../../domain/Kayenta';
  * {@see: https://github.com/spinnaker/kayenta/blob/master/kayenta-prometheus/src/main/java/com/netflix/kayenta/canary/providers/metrics/PrometheusCanaryMetricSetQueryConfig.java}
  */
 export default interface PrometheusCanaryMetricSetQueryConfig extends CanaryMetricSetQueryConfig {
-  customInlineTemplate: string
+  customInlineTemplate: string;
 }

--- a/packages/client/src/metricSources/Prometheus/index.ts
+++ b/packages/client/src/metricSources/Prometheus/index.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { MetricSourceIntegration } from '../MetricSourceIntegration';
 import { MetricModalProps } from '../../components/config/AbstractMetricModal';
 import PrometheusMetricModal from './PrometheusMetricModal';
-import PrometheusCanaryMetricSetQueryConfig from './PrometheusCanaryMetricSetQueryConfig'
+import PrometheusCanaryMetricSetQueryConfig from './PrometheusCanaryMetricSetQueryConfig';
 import { string } from 'yup';
 
 export const PROMETHEUS_SERVICE_TYPE: string = 'prometheus';

--- a/packages/client/src/metricSources/index.tsx
+++ b/packages/client/src/metricSources/index.tsx
@@ -4,7 +4,6 @@ import NewRelic from './NewRelic';
 import SignalFx from './SignalFx';
 import Prometheus from './Prometheus';
 
-
 const MIN_TO_MS_CONVERSION: number = 60000;
 /**
  * The list of enabled metric source integrations

--- a/packages/client/src/services/KayentaApiService.ts
+++ b/packages/client/src/services/KayentaApiService.ts
@@ -74,18 +74,6 @@ export default class KayentaApiService {
     }
   }
 
-  async fetchCanaryAnalysisExecutionStatusResponseFromNikeKayenta(
-    executionId: string
-  ): Promise<CanaryAnalysisExecutionStatusResponse> {
-    try {
-      const response = await kayentaClient.get('/v2/standalone_canary_analysis/' + executionId);
-      return response.data;
-    } catch (e) {
-      log.error(`Failed to fetch standalone canary analysis pipeline execution status from Nike Kayenta`, e);
-      throw e;
-    }
-  }
-
   async fetchCanaryConfig(configId: string): Promise<CanaryConfig> {
     try {
       const response = await kayentaClient.get(`/canaryConfig/${configId}`);

--- a/packages/client/src/services/KayentaApiService.ts
+++ b/packages/client/src/services/KayentaApiService.ts
@@ -74,7 +74,9 @@ export default class KayentaApiService {
     }
   }
 
-  async fetchCanaryAnalysisExecutionStatusResponseFromNikeKayenta(executionId: string): Promise<CanaryAnalysisExecutionStatusResponse> {
+  async fetchCanaryAnalysisExecutionStatusResponseFromNikeKayenta(
+    executionId: string
+  ): Promise<CanaryAnalysisExecutionStatusResponse> {
     try {
       const response = await kayentaClient.get('/v2/standalone_canary_analysis/' + executionId);
       return response.data;

--- a/packages/client/src/services/KayentaApiService.ts
+++ b/packages/client/src/services/KayentaApiService.ts
@@ -74,6 +74,16 @@ export default class KayentaApiService {
     }
   }
 
+  async fetchCanaryAnalysisExecutionStatusResponseFromNikeKayenta(executionId: string): Promise<CanaryAnalysisExecutionStatusResponse> {
+    try {
+      const response = await kayentaClient.get('/v2/standalone_canary_analysis/' + executionId);
+      return response.data;
+    } catch (e) {
+      log.error(`Failed to fetch standalone canary analysis pipeline execution status from Nike Kayenta`, e);
+      throw e;
+    }
+  }
+
   async fetchCanaryConfig(configId: string): Promise<CanaryConfig> {
     try {
       const response = await kayentaClient.get(`/canaryConfig/${configId}`);

--- a/packages/client/src/stores/ConfigEditorStore.ts
+++ b/packages/client/src/stores/ConfigEditorStore.ts
@@ -97,7 +97,9 @@ export default class ConfigEditorStore {
   @action.bound
   setCanaryConfigObject(canaryConfigObject: CanaryConfig): void {
     // account for ad-hoc configurations with nested 'canaryConfig' object
-    canaryConfigObject.metrics == null && canaryConfigObject.canaryConfig != null ? this.canaryConfigObject = canaryConfigObject.canaryConfig : this.canaryConfigObject = canaryConfigObject
+    canaryConfigObject.metrics == null && canaryConfigObject.canaryConfig != null
+      ? (this.canaryConfigObject = canaryConfigObject.canaryConfig)
+      : (this.canaryConfigObject = canaryConfigObject);
     this.canaryConfigObject.metrics.forEach(metric => metric.groups.forEach(g => this.createNewGroup(g, false)));
     this.hasTheCopyOrSaveButtonBeenClicked = false;
     const uniqueGroups = new Set();

--- a/packages/client/src/stores/ReportStore.ts
+++ b/packages/client/src/stores/ReportStore.ts
@@ -105,10 +105,14 @@ export default class ReportStore {
     this.scapeExecutionRequest = scapeExecutionStatusResponse.canaryAnalysisExecutionRequest as CanaryAnalysisExecutionRequest;
 
     if (scapeExecutionStatusResponse.startTimeIso != null) {
-      this.startTime = safeGet(() => this.scapeExecutionRequest!.scopes[0].startTimeIso as string).orElse(scapeExecutionStatusResponse.startTimeIso);
+      this.startTime = safeGet(() => this.scapeExecutionRequest!.scopes[0].startTimeIso as string).orElse(
+        scapeExecutionStatusResponse.startTimeIso
+      );
     }
     if (scapeExecutionStatusResponse.endTimeIso != null) {
-      this.endTime = safeGet(() => this.scapeExecutionRequest!.scopes[0].endTimeIso as string).orElse(scapeExecutionStatusResponse.endTimeIso);
+      this.endTime = safeGet(() => this.scapeExecutionRequest!.scopes[0].endTimeIso as string).orElse(
+        scapeExecutionStatusResponse.endTimeIso
+      );
     }
 
     safeGet(() => this.scapeResults).ifPresent(results => {

--- a/packages/client/src/stores/ReportStore.ts
+++ b/packages/client/src/stores/ReportStore.ts
@@ -107,7 +107,7 @@ export default class ReportStore {
     this.endTime = scapeExecutionStatusResponse.endTimeIso as string;
 
     safeGet(() => this.scapeResults).ifPresent(results => {
-      const lastRun = results.canaryScores.length - 1;
+      const lastRun = safeGet(() => results.canaryExecutionResults.length - 1).orElse(0);
       this.selectedCanaryExecutionResult = results.canaryExecutionResults[lastRun];
       this.canaryResult = this.selectedCanaryExecutionResult.result;
       this.metricSetPairListId = this.selectedCanaryExecutionResult.metricSetPairListId as string;

--- a/packages/client/src/stores/ReportStore.ts
+++ b/packages/client/src/stores/ReportStore.ts
@@ -103,8 +103,13 @@ export default class ReportStore {
     this.scapeExecutionStatusResponse = scapeExecutionStatusResponse;
     this.scapeResults = scapeExecutionStatusResponse.canaryAnalysisExecutionResult as CanaryAnalysisExecutionResult;
     this.scapeExecutionRequest = scapeExecutionStatusResponse.canaryAnalysisExecutionRequest as CanaryAnalysisExecutionRequest;
-    this.startTime = scapeExecutionStatusResponse.startTimeIso as string;
-    this.endTime = scapeExecutionStatusResponse.endTimeIso as string;
+
+    if (scapeExecutionStatusResponse.startTimeIso != null) {
+      this.startTime = safeGet(() => this.scapeExecutionRequest!.scopes[0].startTimeIso as string).orElse(scapeExecutionStatusResponse.startTimeIso);
+    }
+    if (scapeExecutionStatusResponse.endTimeIso != null) {
+      this.endTime = safeGet(() => this.scapeExecutionRequest!.scopes[0].endTimeIso as string).orElse(scapeExecutionStatusResponse.endTimeIso);
+    }
 
     safeGet(() => this.scapeResults).ifPresent(results => {
       const lastRun = safeGet(() => results.canaryExecutionResults.length - 1).orElse(0);

--- a/packages/client/src/stores/ReportStore.ts
+++ b/packages/client/src/stores/ReportStore.ts
@@ -12,7 +12,8 @@ import {
   CanaryResult,
   MetricSetPair
 } from '../domain/Kayenta';
-import { safeGet } from '../util/OptionalUtils';
+import { mapIfPresent, safeGet } from '../util/OptionalUtils';
+import Optional from 'optional-js';
 
 enum classifications {
   FAIL = 'Fail',
@@ -185,10 +186,11 @@ export default class ReportStore {
     }
 
     const metricSetPairsByIdMap: KvMap<MetricSetPair> = {};
-    metricSetPairList.forEach(metricSetPair => {
-      metricSetPairsByIdMap[metricSetPair.id] = metricSetPair;
-    });
-
+    mapIfPresent(Optional.ofNullable(metricSetPairList), metricSetPairList =>
+      metricSetPairList.forEach(metricSetPair => {
+        metricSetPairsByIdMap[metricSetPair.id] = metricSetPair;
+      })
+    );
     return metricSetPairsByIdMap;
   }
 

--- a/packages/client/src/styles/shared.scss
+++ b/packages/client/src/styles/shared.scss
@@ -9,6 +9,7 @@ $nodata: #bbb;
 $dark-background-color: #222222;
 $dark-bg-font-color: #F7F7F7;
 $off-white: #f2f2f2;
+$light-gray: #d6d6d6;
 
 $pass-color: $success;
 $marginal-color: yellow;
@@ -93,6 +94,10 @@ $fail-color: $error;
 
 .marginal {
   background: $marginal-color;
+}
+
+.in-progress {
+  background: $light-gray;
 }
 
 .pass {

--- a/packages/client/src/util/ScoreClassUtils.ts
+++ b/packages/client/src/util/ScoreClassUtils.ts
@@ -1,4 +1,5 @@
 import { CanaryClassifierThresholdsConfig } from '../domain/Kayenta';
+import { safeGet } from './OptionalUtils';
 
 export function getClassFromScore(
   score: number,
@@ -7,7 +8,7 @@ export function getClassFromScore(
   canaryRunIndex: number
 ) {
   const { pass, marginal } = scoreThresholds;
-  const isLastCanaryExecution = canaryRunIndex + 1 === canaryScores.length;
+  const isLastCanaryExecution = canaryRunIndex + 1 === safeGet(() => canaryScores.length).orElse(0);
 
   if (isLastCanaryExecution) {
     return score < pass ? 'fail' : 'pass';

--- a/packages/client/src/validation/configValidators.ts
+++ b/packages/client/src/validation/configValidators.ts
@@ -144,15 +144,15 @@ export const validateCanaryMetricConfig = (
   const errors: KvMap<string> = {};
   try {
     let querySchema: KvMap<Schema<any>> = {};
-      if (isQueryTypeSimple) {
-        querySchema = metricSourceIntegrations()[type].canaryMetricSetQueryConfigSchema;
-      } else {
-        if (type == 'prometheus') {
-          querySchema = customPrometheusQueryScheme;
-        } else if (type == 'signalfx') {
-          querySchema = customSignalFXQuerySchema;
-        }
+    if (isQueryTypeSimple) {
+      querySchema = metricSourceIntegrations()[type].canaryMetricSetQueryConfigSchema;
+    } else {
+      if (type == 'prometheus') {
+        querySchema = customPrometheusQueryScheme;
+      } else if (type == 'signalfx') {
+        querySchema = customSignalFXQuerySchema;
       }
+    }
     getCanaryMetricConfigSchema(querySchema).validateSync(metric, { abortEarly: false, strict: true });
   } catch (e) {
     error = e;


### PR DESCRIPTION
This feature enables in progress reports to allow users to view results of canary runs during canary analysis.

Canary Analysis started:
![image](https://user-images.githubusercontent.com/42477256/77667782-e1321500-6f3f-11ea-9576-87d57bfca4f8.png)

Canary Analysis in progress (pass):
![image](https://user-images.githubusercontent.com/42477256/77667856-f6a73f00-6f3f-11ea-8b11-92369d2212b3.png)

Canary Analysis in progress (marginal):
![image](https://user-images.githubusercontent.com/42477256/77667894-0161d400-6f40-11ea-83db-86434b9ffa70.png)

Canary Analysis complete:
![image](https://user-images.githubusercontent.com/42477256/77667930-0a52a580-6f40-11ea-9d0e-c7b4569228a3.png)


