### PR TITLE
fix: round computed group weights

### DIFF
--- a/packages/client/src/components/config/ScoringSection.tsx
+++ b/packages/client/src/components/config/ScoringSection.tsx
@@ -75,7 +75,7 @@ export const ScoringSection = observer(
                 </div>
               </Col>
             </div>
-            <div className="weight-total">Weight Total: {Object.values(computedGroupWeights).reduce(add, 0)} / 100</div>
+            <div className="weight-total">Weight Total: {Math.round(Object.values(computedGroupWeights).reduce(add, 0))} / 100</div>
           </Form.Group>
         </div>
         {touched && error && <Alert variant="danger">{error}</Alert>}

--- a/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
+++ b/packages/client/src/components/reports/scape/ScapeReportViewer.tsx
@@ -86,10 +86,10 @@ export default class ScapeReportViewer extends ConnectedComponent<Props, Stores,
         this.stores.configEditorStore.setCanaryConfigObject(canaryConfig);
       }
 
-      const totalGroupWeights: number = Object.values(this.stores.configEditorStore.computedGroupWeights).reduce(
+      const totalGroupWeights: number = Math.round(Object.values(this.stores.configEditorStore.computedGroupWeights).reduce(
         add,
         0
-      );
+      ));
       if (totalGroupWeights !== 100) {
         log.error(`Configuration Error: Group weights need to add up to 100.`);
         this.stores.errorStore.push({

--- a/packages/client/src/validation/configValidators.ts
+++ b/packages/client/src/validation/configValidators.ts
@@ -70,7 +70,7 @@ const groupWeightSchema = object()
     message: 'FormGroup weights should add up to 100',
     test: sut => {
       try {
-        return (Object.values(sut) as number[]).reduce(add) === 100;
+        return Math.round((Object.values(sut) as number[]).reduce(add)) === 100;
       } catch (e) {
         return false;
       }


### PR DESCRIPTION
In our configuration we have three groups with weights set to 33.4, 33.3, and 33.3. When referee computes the total of the weights it gets 99.9999999... when it should be an even 100. (i blame javascript 😄 ) See screenshots:

<img width="1306" alt="Screen Shot 2020-04-22 at 11 14 50 AM" src="https://user-images.githubusercontent.com/14285693/80116198-47b05000-854b-11ea-8489-70a72e2b214a.png">
and:
<img width="1282" alt="Screen Shot 2020-04-23 at 10 02 05 AM" src="https://user-images.githubusercontent.com/14285693/80116202-4a12aa00-854b-11ea-8256-1bdc8ebd9880.png">

This PR adds rounding on the computed group weights to achieve this result:
<img width="1270" alt="Screen Shot 2020-04-23 at 10 13 04 AM" src="https://user-images.githubusercontent.com/14285693/80116231-54cd3f00-854b-11ea-9a76-b4ef8101ee5a.png">

I believe i hit all the places where the group weights are summed but please let me know if I missed it somewhere and i can add it in.
