### PR TITLE
fix: increase advanced config consistency

### DIFF
--- a/packages/client/src/components/config/AbstractMetricModal.tsx
+++ b/packages/client/src/components/config/AbstractMetricModal.tsx
@@ -33,6 +33,10 @@ const initialState = {
     metricName: false,
     aggregationMethod: false,
     dimensions: false,
+    criticalIncrease: false,
+    criticalDecrease: false,
+    allowedIncrease: false,
+    allowedDecrease: false,
     outlierStrategy: false
   },
   isValid: true,
@@ -47,7 +51,15 @@ const initialMetricState = {
   analysisConfigurations: {
     canary: {
       direction: 'either',
-      nanStrategy: 'remove'
+      critical: false,
+      nanStrategy: 'remove',
+      effectSize: {
+        allowedIncrease: 1,
+        allowedDecrease: 1
+      },
+      outliers: {
+        strategy: 'keep'
+      }
     }
   },
   scopeName: 'default'
@@ -304,6 +316,10 @@ export abstract class AbstractMetricModal<T extends CanaryMetricSetQueryConfig> 
     if (criticality === 'critical') {
       delete canaryAnalysisConfigurationCopy['mustHaveData'];
       canaryAnalysisConfigurationCopy['critical'] = true;
+      canaryAnalysisConfigurationCopy['effectSize'] = {
+        criticalIncrease: 1,
+        criticalDecrease: 1
+      };
     }
 
     if (criticality === 'mustHaveData') {
@@ -312,8 +328,12 @@ export abstract class AbstractMetricModal<T extends CanaryMetricSetQueryConfig> 
     }
 
     if (criticality === 'normal') {
-      delete canaryAnalysisConfigurationCopy['critical'];
+      canaryAnalysisConfigurationCopy['critical'] = false;
       delete canaryAnalysisConfigurationCopy['mustHaveData'];
+      canaryAnalysisConfigurationCopy['effectSize'] = {
+        allowedIncrease: 1,
+        allowedDecrease: 1
+      };
     }
 
     this.setState(
@@ -631,7 +651,7 @@ export abstract class AbstractMetricModal<T extends CanaryMetricSetQueryConfig> 
                           <InlineTextGroup
                             id="criticalIncrease"
                             label="Critical Increase"
-                            touched={this.state.touched['analysisConfigurations.canary.effectSize.criticalIncrease']}
+                            touched={this.state.touched.criticalIncrease}
                             error={this.state.errors['analysisConfigurations.canary.effectSize.criticalIncrease']}
                             value={this.getEffectSizeObject('criticalIncrease')}
                             onChange={e => this.handleEffectSizeObjectChange('criticalIncrease', e.target.value)}
@@ -645,7 +665,7 @@ export abstract class AbstractMetricModal<T extends CanaryMetricSetQueryConfig> 
                           <InlineTextGroup
                             id="criticalDecrease"
                             label="Critical Decrease"
-                            touched={this.state.touched['analysisConfigurations.canary.effectSize.criticalDecrease']}
+                            touched={this.state.touched.criticalDecrease}
                             error={this.state.errors['analysisConfigurations.canary.effectSize.criticalDecrease']}
                             value={this.getEffectSizeObject('criticalDecrease')}
                             onChange={e => this.handleEffectSizeObjectChange('criticalDecrease', e.target.value)}
@@ -662,7 +682,7 @@ export abstract class AbstractMetricModal<T extends CanaryMetricSetQueryConfig> 
                           <InlineTextGroup
                             id="allowedIncrease"
                             label="Allowed Increase"
-                            touched={this.state.touched['analysisConfigurations.canary.effectSize.allowedIncrease']}
+                            touched={this.state.touched.allowedIncrease}
                             error={this.state.errors['analysisConfigurations.canary.effectSize.allowedIncrease']}
                             value={this.getEffectSizeObject('allowedIncrease')}
                             onChange={e => this.handleEffectSizeObjectChange('allowedIncrease', e.target.value)}
@@ -676,7 +696,7 @@ export abstract class AbstractMetricModal<T extends CanaryMetricSetQueryConfig> 
                           <InlineTextGroup
                             id="allowedDecrease"
                             label="Allowed Decrease"
-                            touched={this.state.touched['analysisConfigurations.canary.effectSize.allowedDecrease']}
+                            touched={this.state.touched.allowedDecrease}
                             error={this.state.errors['analysisConfigurations.canary.effectSize.allowedDecrease']}
                             value={this.getEffectSizeObject('allowedDecrease')}
                             onChange={e => this.handleEffectSizeObjectChange('allowedDecrease', e.target.value)}
@@ -773,7 +793,11 @@ export abstract class AbstractMetricModal<T extends CanaryMetricSetQueryConfig> 
                       scopeName: true,
                       metricName: true,
                       aggregationMethod: true,
-                      dimensions: true
+                      dimensions: true,
+                      criticalIncrease: true,
+                      criticalDecrease: true,
+                      allowedIncrease: true,
+                      allowedDecrease: true
                     }
                   });
                   return;

--- a/packages/client/src/domain/Kayenta.ts
+++ b/packages/client/src/domain/Kayenta.ts
@@ -146,7 +146,7 @@ export interface CanaryAnalysisConfiguration {
   nanStrategy?: string;
   critical?: boolean;
   mustHaveData?: boolean;
-  effectSize?: CanaryMetricEffectSizeConfigs;
+  effectSize?: CanaryMetricEffectSizeConfig;
   outliers?: CanaryMetricOutliersConfig;
 }
 
@@ -174,10 +174,6 @@ export interface CanaryMetricEffectSizeConfig {
   allowedDecrease?: number;
   criticalIncrease?: number;
   criticalDecrease?: number;
-}
-
-export interface CanaryMetricEffectSizeConfigs {
-  [name: string]: CanaryMetricEffectSizeConfig;
 }
 
 export interface CanaryJudgeConfig {

--- a/packages/client/src/validation/configValidators.ts
+++ b/packages/client/src/validation/configValidators.ts
@@ -40,11 +40,16 @@ const getCanaryMetricConfigSchema = (metricQueryObjectSchema: KvMap<Schema<any>>
             nanStrategy: mixed().oneOf(['remove', 'replace']),
             critical: boolean(),
             mustHaveData: boolean(),
-            effectSize: object().shape({
-              allowedIncrease: number(),
-              allowedDecrease: number(),
-              criticalIncrease: number(),
-              criticalDecrease: number()
+            effectSize: object().when('critical', {
+              is: true,
+              then: object({
+                criticalIncrease: number().required('Critical Increase is a required field. Defaults to 1.'),
+                criticalDecrease: number().required('Critical Decrease is a required field. Defaults to 1.')
+              }),
+              otherwise: object({
+                allowedIncrease: number().required('Allowed Increase is a required field. Defaults to 1.'),
+                allowedDecrease: number().required('Allowed Decrease is a required field. Defaults to 1.')
+              })
             }),
             outliers: object().shape({
               strategy: string().oneOf(['keep', 'remove']),


### PR DESCRIPTION
This PR increases the consistency of Canary Configuration for users by including fields even if default values are being used. 

**Context**: Previously, if some fields in the Canary Config form for a metric were left blank, default values for those fields would be used and the fields would not appear in the Canary Config JSON for users. This resulted in some confusion for users. Additionally there was inconsistency in how the fields under Advanced Configuration for a metric were captured in the Canary Config JSON.

**Potential Changes for Users:** If users import old Canary Config into the Canary Configuration Manager, they might see changes in their Canary Config and additional fields for a metric will appear to have been added. Those fields represent the default values that were already being used in their configuration.

The Canary Configuration fields for a metric affected include:

- `critical`
- `nanStrategy`
- `effectSize`
- `outliers`
