### PR TITLE
CORE Added the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:10-alpine3.10
+
+WORKDIR /opt/referee
+
+# Other dependencies
+RUN apk add python make bash
+
+COPY package.json yarn.lock lerna.json ./ 
+
+RUN yarn
+RUN yarn install
+RUN yarn bootstrap
+
+COPY . .
+
+RUN npm rebuild node-sass
+
+EXPOSE 3000
+CMD yarn start


### PR DESCRIPTION
The Referee project currently lacks a dockerfile, this adds one so we can start it with nomad.