### PR TITLE
Bump setup-node in GitHub Action workflow

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
       - run: sudo apt-get -qq update
       - run: sudo apt-get install -y oathtool
       - run: yarn prepare-artifacts


### PR DESCRIPTION
## What
Bump the `action/setup-node` to `v2` to maintain. There are no breaking change.

## Ref

* [action/setup-node, GitHub](https://github.com/actions/setup-node)