### PR TITLE
Add missing metric source list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Kayenta has many metrics source integrations, this project does not currently su
 Referee currently supports
 
 - New Relic Insights
+- Prometheus
 - SignalFx
 
 To add a new integration you must implement the [MetricSourceIntegration](/packages/client/src/metricSources/MetricSourceIntegration.ts) interface and then add it to the [enabled metric sources](/packages/client/src/metricSources/index.tsx).


### PR DESCRIPTION
## What
Add missing `Prothemeus` metric store in the README.