### PR TITLE
Add support for datadog as a metric source

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Referee currently supports
 - New Relic Insights
 - Prometheus
 - SignalFx
+- Datadog
 
 To add a new integration you must implement the [MetricSourceIntegration](/packages/client/src/metricSources/MetricSourceIntegration.ts) interface and then add it to the [enabled metric sources](/packages/client/src/metricSources/index.tsx).
 

--- a/packages/client/src/metricSources/Datadog/DatadogCanaryMetricSetQueryConfig.ts
+++ b/packages/client/src/metricSources/Datadog/DatadogCanaryMetricSetQueryConfig.ts
@@ -1,0 +1,8 @@
+import { CanaryMetricSetQueryConfig } from '../../domain/Kayenta';
+
+/**
+ * {@see: https://github.com/spinnaker/kayenta/blob/master/kayenta-datadog/src/main/java/com/netflix/kayenta/canary/providers/metrics/DatadogCanaryMetricSetQueryConfig.java}
+ */
+export default interface DatadogCanaryMetricSetQueryConfig extends CanaryMetricSetQueryConfig {
+    customInlineTemplate: string
+}

--- a/packages/client/src/metricSources/Datadog/DatadogMetricModal.tsx
+++ b/packages/client/src/metricSources/Datadog/DatadogMetricModal.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { AbstractMetricModal } from '../../components/config/AbstractMetricModal';
+import { DATADOG_SERVICE_TYPE } from './index';
+import { InlineTextGroup } from '../../layout/InlineTextGroup';
+import { validateCanaryMetricConfig } from '../../validation/configValidators';
+import { CanaryMetricConfig } from '../../domain/Kayenta';
+import { ValidationResultsWrapper } from '../../domain/Referee';
+import DatadogCanaryMetricSetQueryConfig from './DatadogCanaryMetricSetQueryConfig';
+
+export default class DatadogMetricModal extends AbstractMetricModal<DatadogCanaryMetricSetQueryConfig> {
+  validateCanaryMetricConfig(existingMetric: CanaryMetricConfig, type: string): ValidationResultsWrapper {
+    return validateCanaryMetricConfig(existingMetric, type, true);
+  }
+
+  getQueryInitialState(): DatadogCanaryMetricSetQueryConfig {
+    return {
+        type: DATADOG_SERVICE_TYPE,
+        customInlineTemplate: '',
+    };
+  }
+
+  getMetricSourceSpecificJsx(): JSX.Element {
+    return (
+      <div>
+        <InlineTextGroup
+          onBlur={() => {
+            this.touch('customInlineTemplate');
+          }}
+          touched={this.state.touched.customInlineTemplate}
+          error={this.state.errors['query.customInlineTemplate']}
+          id="customInlineTemplate"
+          label="Datadog Query"
+          value={this.state.metric.query.customInlineTemplate}
+          onChange={e => this.updateQueryObject('customInlineTemplate', e.target.value)}
+          placeHolderText="sum:requests.error{${scope}}.as_count() / sum:requests.total{${scope}}.as_count()"
+          subText="Custom datadog query; use ${scope} as a placeholder for your tags."
+        />
+      </div>
+    );
+  }
+}

--- a/packages/client/src/metricSources/Datadog/index.ts
+++ b/packages/client/src/metricSources/Datadog/index.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { MetricSourceIntegration } from '../MetricSourceIntegration';
+import { MetricModalProps } from '../../components/config/AbstractMetricModal';
+import DatadogMetricModal from './DatadogMetricModal';
+import DatadogCanaryMetricSetQueryConfig from './DatadogCanaryMetricSetQueryConfig';
+import { string } from 'yup';
+
+export const DATADOG_SERVICE_TYPE: string = 'datadog';
+
+const schema = {
+  customInlineTemplate: string()
+      .trim()
+      .required()
+};
+
+const modalFactory = (props: MetricModalProps) => React.createElement(DatadogMetricModal, props);
+
+const Datadog: MetricSourceIntegration<DatadogCanaryMetricSetQueryConfig> = {
+  type: DATADOG_SERVICE_TYPE,
+  createMetricsModal: modalFactory,
+  canaryMetricSetQueryConfigSchema: schema
+};
+
+export default Datadog;

--- a/packages/client/src/metricSources/index.tsx
+++ b/packages/client/src/metricSources/index.tsx
@@ -3,6 +3,7 @@ import { MetricSourceIntegration } from './MetricSourceIntegration';
 import NewRelic from './NewRelic';
 import SignalFx from './SignalFx';
 import Prometheus from './Prometheus';
+import Datadog from './Datadog';
 
 const MIN_TO_MS_CONVERSION: number = 60000;
 /**
@@ -12,7 +13,8 @@ const MIN_TO_MS_CONVERSION: number = 60000;
 const enabledMetricSources: MetricSourceIntegration<CanaryMetricSetQueryConfig>[] = [
   NewRelic,
   SignalFx,
-  Prometheus
+  Prometheus,
+  Datadog
 ];
 
 /**


### PR DESCRIPTION
Hi there, this adds basic support for Datadog as a metric source - basically like #61 but tweaked for Datadog. see also, #69. 

Although Kayenta does provide integration with the MetricSetQueryConfig with uhh ... [metricName, and customFilterTemplate and all](https://github.com/spinnaker/kayenta/blob/7fd1ded37aadf280b28215191723afcf9a1f3db8/kayenta-datadog/src/main/java/com/netflix/kayenta/canary/providers/metrics/DatadogCanaryMetricSetQueryConfig.java#L37-L41), I opted for ... just having the user provide the whole Datadog query and using `${scope}` as a placeholder for the tags, as supported in kayenta by https://github.com/spinnaker/kayenta/pull/657#issue-367673875. As someone unfamiliar with kayenta terminology, this seemed more straightforward to me, as that's how we structure our datadog queries for monitors and dashboards (pick a metric/query you're interested in, and then filter it down to the right $scope).

----
manual testing:

With these changes, I was able to edit a config, choose datadog as the source, run test executions, and view graphs in referee of the metrics pulled from datadog. 

<img src=https://user-images.githubusercontent.com/1437272/109036401-68bb6300-767e-11eb-90f3-015b7e8b52a3.png width=180>
<img src=https://user-images.githubusercontent.com/1437272/109038671-d23c7100-7680-11eb-8ca1-a36d0af89047.png width=800>
<img src=https://user-images.githubusercontent.com/1437272/109039394-97870880-7681-11eb-8af9-21c2b0fdeeaa.png width=800>
<img src=https://user-images.githubusercontent.com/1437272/109039675-e92f9300-7681-11eb-9600-f7de0be71190.png width=640>



